### PR TITLE
Removed numberOfParticles, reused numberOfEvents

### DIFF
--- a/src/protontherapy/Geometry.java
+++ b/src/protontherapy/Geometry.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Random;
+import static protontherapy.ProtonTherapy.randGen;
 
 class Geometry
 {
@@ -37,7 +38,7 @@ class Geometry
     private EnergyLoss [] Eloss;
     private MCS [] MultScatter;
     
-    private Voxel z_hist;
+    private Voxel energy_hist;
 
     private double minfeaturesize;
     
@@ -63,7 +64,7 @@ class Geometry
         double [] binlow = {-0.2, -0.2, 0.2};
         double [] binhigh = {0.2, 0.2, 0.71};
         
-        z_hist = new Voxel(400, binlow, binhigh, "Z Slices");
+        energy_hist = new Voxel(400, binlow, binhigh, "Z Slices");
     }
 
     public int getNshapes() { return nshapes; }
@@ -174,14 +175,16 @@ class Geometry
 //                System.out.println("Dog");
 //                System.out.println(lostE);
 //                System.out.println(p.z);
-                 z_hist.fill(lostE, p);
+//                double stdev = 0.1;
+//                double smearing = randGen.nextGaussian()*stdev;
+                energy_hist.fill(lostE, p);
 
             }
         }
     }
  
-    public void writeEnergyHist(){
-        z_hist.writeToDisk("energy_hist.csv");
+    public void writeEnergyHist(String filename){
+        energy_hist.writeToDisk(filename);
     }
     
     public void doMultScatter(Particle p, double dist)

--- a/src/protontherapy/Geometry.java
+++ b/src/protontherapy/Geometry.java
@@ -181,7 +181,7 @@ class Geometry
     }
  
     public void writeEnergyHist(){
-        z_hist.writeToDisk("energy_hist3.csv");
+        z_hist.writeToDisk("energy_hist.csv");
     }
     
     public void doMultScatter(Particle p, double dist)

--- a/src/protontherapy/ProtonTherapy.java
+++ b/src/protontherapy/ProtonTherapy.java
@@ -1,5 +1,6 @@
 package protontherapy;
 
+import java.util.Arrays;
 import java.util.Random;
 
 class ProtonTherapy
@@ -58,10 +59,10 @@ class ProtonTherapy
     static final double startAngle = 0;      // Radians
     
     // Number of events to simulate (ie. the number of particles)
-    static final int numberOfEvents = 10000;
+    static int numberOfEvents = 10000;
     
     // Energy ranges for when we add multiple energy ranges to flatten dose area
-    static final double [] energies = getEnergies(230, 250);
+    static final double [][] energies = getEnergies(230, 250);
     
     static final double delta = 0.2; // for det hists
     static final double delta_A = 0.05; //For first 4 hists gen and sim theta
@@ -73,6 +74,7 @@ class ProtonTherapy
     
     public static void main (String [] args )
     {
+        //System.out.println(Arrays.deepToString(energies));
         // setup histograms for analysis
         Histogram hist_gen_mom = new Histogram(50, 0., 150*1.01, "initial generated Momentum");
         Histogram hist_sim_mom = new Histogram(50, 0., 150*1.01, "simulated final Momentum");
@@ -100,6 +102,10 @@ class ProtonTherapy
                 
         for(int ke = 0; ke < energies.length; ke++){
             // start of main loop: run the simulation numberOfEvents times
+            
+            // Added for weighting the subsequent beams
+            numberOfEvents = (int) Math.rint( numberOfEvents*energies[ke][1]);
+            
             for (int nev = 0; nev < numberOfEvents; nev++) {
 
                 if (nev % 1000 == 0) {
@@ -107,7 +113,7 @@ class ProtonTherapy
                 }
 
                 // get the particles of the event to simulate
-                Particle [] Particles_gen = GetParticles(energies[ke]);
+                Particle [] Particles_gen = GetParticles(energies[ke][0]);
 
                 // simulate propagation of each generated particle,
                 // store output in Particles_sim and Tracks_sim
@@ -325,12 +331,17 @@ class ProtonTherapy
         return Particles_gen;
     }
     
-    public static double[] getEnergies(double start, double end){
-        int steps = (int) (end-start);
-        double [] values = new double[steps];
+    public static double[][] getEnergies(double start, double end){
+        int steps = (int) (end-start) +1;
+        double [][] values = new double[steps][2];
+        double fraction = 1;
         
         for(int i = 0; i < steps; i++){
-            values[i] = start+i;
+            values[i][0] = end-i;
+            
+            // The fraction by which to reduce the nev
+            values[i][1] = fraction;
+            fraction = fraction - ((double)1/steps);
         }
         
         return values;

--- a/src/protontherapy/ProtonTherapy.java
+++ b/src/protontherapy/ProtonTherapy.java
@@ -54,17 +54,14 @@ class ProtonTherapy
 
     // start values
     //static final double startMomentum = 150.; // MeV
-    static final double startKineticEnergy = 150.; // MeV
+    static final double startKineticEnergy = 245.; // MeV
     static final double startAngle = 0;      // Radians
     
-    // Number of events to simulate
-    static final int numberOfEvents = 1;    // Keep as 1 
+    // Number of events to simulate (ie. the number of particles)
+    static final int numberOfEvents = 10000;
     
     // Energy ranges for when we add multiple energy ranges to flatten dose area
     static final int [] energies = {250, 250};
-    
-    // Number of particles to generate 
-    static final int numberOfParticles = 100;
     
     static final double delta = 0.2; // for det hists
     static final double delta_A = 0.05; //For first 4 hists gen and sim theta
@@ -107,11 +104,9 @@ class ProtonTherapy
             if (nev % 1000 == 0) {
                 //System.out.println("Simulating event " + nev);
             }
-            
-            System.out.println(energies[nev]);
 
             // get the particles of the event to simulate
-            Particle [] Particles_gen = GetParticles(energies[nev]);
+            Particle [] Particles_gen = GetParticles();
 
             // simulate propagation of each generated particle,
             // store output in Particles_sim and Tracks_sim
@@ -291,41 +286,39 @@ class ProtonTherapy
     }
 
     
-    public static Particle[] GetParticles(double value)
+    public static Particle[] GetParticles()
     {
+        //System.out.println("p");
         // example to simulate just one proton starting at (0,0,0)
         // with a total momentum startMomentum and theta=startAngle
         // we follow the particle physics "convention"
         // to have the z-axis in the (approximate) direction of the beam
         // this just sets up the array (for a case where one event has more than one particle)
-        Particle [] Particles_gen = new Particle[numberOfParticles];
+        Particle [] Particles_gen = new Particle[1];
         
         // converting input kinetic energy to momentum
-        double startMomentum = Math.sqrt((938+value)*(938+value)-(938*938));
+        double startMomentum = Math.sqrt((938+startKineticEnergy)*(938+startKineticEnergy)-(938*938));
 //        System.out.println(startMomentum);
         
-        //  Loop to generate desired amount of particles
-        for(int i=0;i<numberOfParticles;i++){
-            // create particle and set properties
-            Particles_gen[i] = new Particle();
+        // create particle and set properties
+        Particles_gen[0] = new Particle();
 
-            // initial momentum px,py,pz (MeV)
-            double phi = 0;
-            Particles_gen[i].px = startMomentum*Math.sin(startAngle)*Math.cos(phi);
-            Particles_gen[i].py = startMomentum*Math.sin(startAngle)*Math.sin(phi);
-            Particles_gen[i].pz = startMomentum*Math.cos(startAngle);
+        // initial momentum px,py,pz (MeV)
+        double phi = 0;
+        Particles_gen[0].px = startMomentum*Math.sin(startAngle)*Math.cos(phi);
+        Particles_gen[0].py = startMomentum*Math.sin(startAngle)*Math.sin(phi);
+        Particles_gen[0].pz = startMomentum*Math.cos(startAngle);
 
-            // Set charge and mass of a positive proton
-            Particles_gen[i].m = 938;
-            Particles_gen[i].Q = +1;  
-            
-            double randValue = 0.2 * randGen.nextDouble();
-            
-            // initial position (x,y,z) = (0,0,0)
-            Particles_gen[i].x = 0;
-            Particles_gen[i].y = 0;
-            Particles_gen[i].z = randValue;
-        }
+        // Set charge and mass of a positive proton
+        Particles_gen[0].m = 938;
+        Particles_gen[0].Q = +1;  
+
+        double randValue = (-0.2)*(0.2+0.2) * randGen.nextDouble();
+
+        // initial position (x,y,z) = (0,0,0)
+        Particles_gen[0].x = 0;
+        Particles_gen[0].y = 0;
+        Particles_gen[0].z = randValue;
 
         return Particles_gen;
     }

--- a/src/protontherapy/Voxel.java
+++ b/src/protontherapy/Voxel.java
@@ -184,7 +184,7 @@ class Voxel
                 outputFile.println(n + "," + binCentre[i][n] + "," + getBinEnergy(i, n) + "," + getError(i, n));
             }
             outputFile.close(); // close the output file
-            System.out.println("File written!");
+            System.out.println(plane[i]+"_"+filename+" written!");
         }
     }
 }


### PR DESCRIPTION
Removed the numberOfParticles way of generating amount of particles an replaced it by using the numberOfEvents. This saves on computing space. Noticed I got Heap Space errors the old way. This is different to how I imagined it initially but works well as generates only one particle at a time instead of many many particles and then propagating each one.